### PR TITLE
Use cache for datastructures of the user/permission management

### DIFF
--- a/app/controllers/change_password_controller.rb
+++ b/app/controllers/change_password_controller.rb
@@ -21,6 +21,8 @@ class ChangePasswordController < ApplicationController
       flash[:error] = user.errors.full_messages.join('; ')
       redirect_to change_password_path
       return
+    else
+      clear_permissions_cache
     end
 
     flash[:success] = 'Password successfully changed'

--- a/app/controllers/privileges_controller.rb
+++ b/app/controllers/privileges_controller.rb
@@ -4,6 +4,7 @@ class PrivilegesController < ApplicationController
     can?(:create, 'privileges') do
       @role = Role.find(params[:role_id])
       @privilege = @role.privileges.create(privilege_params)
+      clear_permissions_cache
       redirect_to edit_role_path(@role)
     end
   end
@@ -13,6 +14,7 @@ class PrivilegesController < ApplicationController
       @role = Role.find(params[:role_id])
       @privilege = @role.privileges.find(params['id'])
       @privilege.destroy
+      clear_permissions_cache
       redirect_to edit_role_path(@role)
     end
   end

--- a/app/controllers/roles_controller.rb
+++ b/app/controllers/roles_controller.rb
@@ -26,6 +26,7 @@ class RolesController < ApplicationController
     can?(:create, 'roles') do
       @role = Role.new(role_params)
       if @role.save
+        clear_permissions_cache
         redirect_to roles_path
       else
         render 'new'
@@ -37,6 +38,7 @@ class RolesController < ApplicationController
     can?(:update, 'roles') do
       @role = Role.find(params['id'])
       if @role.update(role_params)
+        clear_permissions_cache
         redirect_to roles_path
       else
           render 'edit'
@@ -48,6 +50,7 @@ class RolesController < ApplicationController
     can?(:delete, 'roles') do
       @role = Role.find(params['id'])
       @role.destroy
+      clear_permissions_cache
       redirect_to roles_path
     end
   end

--- a/app/controllers/user_roles_controller.rb
+++ b/app/controllers/user_roles_controller.rb
@@ -4,6 +4,7 @@ class UserRolesController < ApplicationController
     can?(:create, 'user_roles') do
       @user = User.find(params[:user_id])
       @user_role = @user.user_roles.create(user_role_params)
+      clear_permissions_cache
       redirect_to edit_user_path(@user)
     end
   end
@@ -13,6 +14,7 @@ class UserRolesController < ApplicationController
       @user = User.find(params[:user_id])
       @user_role = @user.user_roles.find(params['id'])
       @user_role.destroy
+      clear_permissions_cache
       redirect_to edit_user_path(@user)
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -25,6 +25,7 @@ class UsersController < ApplicationController
     can?(:create, 'users') do
       @user = User.new(user_params)
       if @user.save
+        clear_permissions_cache
         redirect_to users_path
       else
         render 'new'
@@ -40,6 +41,7 @@ class UsersController < ApplicationController
       end
 
       if @user.update(user_params)
+        clear_permissions_cache
         redirect_to users_path
       else
           render 'edit'
@@ -51,6 +53,7 @@ class UsersController < ApplicationController
     can?(:delete, 'users') do
       @user = User.find(params['id'])
       @user.destroy
+      clear_permissions_cache
       redirect_to users_path
     end
   end


### PR DESCRIPTION
This PR utilizes the rails cache to store the datastructures of the user/permission management of GenieACS GUI. The cache is cleared if there was a change related to users, roles or permissions.