### PR TITLE
Clear db cache on startup

### DIFF
--- a/config/initializers/roles.rb
+++ b/config/initializers/roles.rb
@@ -1,4 +1,6 @@
 case GenieacsGui::Application.config.auth_method
+when :db
+  GenieacsGui::ApplicationController.new.clear_permissions_cache
 when :yml
   GenieacsGui::Application.config.permissions = YAML.load_file('config/roles.yml')
   GenieacsGui::Application.config.users = YAML.load_file('config/users.yml')


### PR DESCRIPTION
Clear the cache for the users/roles/permissions datastructures on app startup. This ensures that the cache is always up to date, for example if a database import has been done before running the app.